### PR TITLE
Fix NPM warning about invalid package.json property

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
         "type": "MIT",
         "url": "http://opensource.org/licenses/MIT"
     }],
-    "repositories": [{
+    "repository": {
         "type": "git",
         "url": "https://github.com/aaditmshah/lexer.git"
-    }],
+    },
     "dependencies": {},
     "homepage": "https://github.com/aaditmshah/lexer"
 }


### PR DESCRIPTION
I get this warning from NPM when installing this package:

```
npm WARN package.json lex@1.7.6 'repositories' (plural) Not supported. Please pick one as the 'repository' field
```

This PR makes the change recommended by NPM.
