### PR TITLE
Reset tokens when changing input.

### DIFF
--- a/lexer.js
+++ b/lexer.js
@@ -38,6 +38,7 @@ function Lexer(defunct) {
 
     this.setInput = function (input) {
         remove = 0;
+        tokens = [];
         this.state = 0;
         this.index = 0;
         this.input = input;


### PR DESCRIPTION
If a parse failed and a new input is fed to the lexer, leftover tokens from the previous input are returned, which is not desired.
